### PR TITLE
revise: Prepare upgrade (TS-1013)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ deploy-referral:
 upgrade-referral:
 	@forge clean
 	@forge script deploy/01-UpgradeReferralGateway.s.sol:UpgradeReferralGateway $(NETWORK_ARGS)
-	@cp contracts/referrals/ReferralGateway.sol contracts/version_previous_contracts/ReferralGateway.sol
+	@cp contracts/referrals/ReferralGateway.sol contracts/version_previous_contracts/ReferralGatewayV1.sol
 
 deploy-bm-consumer:
 	@forge script deploy/02-DeployBenefitMultiplierConsumer.s.sol:DeployBenefitMultiplierConsumer $(NETWORK_ARGS)
@@ -63,7 +63,12 @@ deploy-all:
 upgrade-referral-defender:
 	@forge clean
 	@forge script deploy/06-DefenderUpgradeReferralGateway.s.sol:DefenderUpgradeReferralGateway $(NETWORK_ARGS)
-	@cp contracts/referrals/ReferralGateway.sol contracts/version_previous_contracts/ReferralGateway.sol
+	@cp contracts/referrals/ReferralGateway.sol contracts/version_previous_contracts/ReferralGatewayV1.sol
+
+prepare-upgrade:
+	@forge clean
+	@forge script deploy/07-DefenderPrepareUpgrade.s.sol:DefenderPrepareUpgrade $(NETWORK_ARGS)
+	@cp contracts/referrals/ReferralGateway.sol contracts/version_previous_contracts/ReferralGatewayV1.sol
 
 # Interactions with ReferralGateway Contract
 # Create a DAO

--- a/contracts/referrals/ReferralGateway.sol
+++ b/contracts/referrals/ReferralGateway.sol
@@ -841,4 +841,7 @@ contract ReferralGateway is
 
         emit OnRefund(_tDAOName, _member, amountToRefund);
     }
+
+    ///@dev required by the OZ UUPS module
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OPERATOR) {}
 }

--- a/contracts/referrals/ReferralGateway.sol
+++ b/contracts/referrals/ReferralGateway.sol
@@ -841,14 +841,4 @@ contract ReferralGateway is
 
         emit OnRefund(_tDAOName, _member, amountToRefund);
     }
-
-    ///@dev required by the OZ UUPS module
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(OPERATOR) {}
-
-    function fixContributionAmount(string calldata tDAOName) external onlyRole(OPERATOR) {
-        nameToDAOData[tDAOName].currentAmount =
-            usdc.balanceOf(address(this)) -
-            nameToDAOData[tDAOName].toRepool -
-            nameToDAOData[tDAOName].referralReserve;
-    }
 }

--- a/contracts/referrals/ReferralGateway.sol
+++ b/contracts/referrals/ReferralGateway.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GNU GPLv3
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @title ReferralGateway

--- a/deploy/07-DefenderPrepareUpgrade.s.sol
+++ b/deploy/07-DefenderPrepareUpgrade.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {ReferralGateway} from "contracts/referrals/ReferralGateway.sol";
+import {Defender, Options, ApprovalProcessResponse} from "openzeppelin-foundry-upgrades/src/Defender.sol";
+import {Upgrades} from "openzeppelin-foundry-upgrades/src/Upgrades.sol";
+
+contract DefenderPrepareUpgrade is Script {
+    function run() external {
+        ApprovalProcessResponse memory approvalProcess = Defender.getDeployApprovalProcess();
+        console2.log("Approval process id", approvalProcess.approvalProcessId);
+        console2.log("Approval process via", approvalProcess.viaType);
+        string memory relayerKey = "RELAYER_ID";
+
+        bytes32 salt = keccak256(abi.encodePacked(block.timestamp, msg.sender));
+
+        Options memory opts;
+        opts.defender.salt = salt;
+        opts.defender.useDefenderDeploy = true;
+        opts.defender.relayerId = vm.envString(relayerKey);
+        opts.defender.upgradeApprovalProcessId = approvalProcess.approvalProcessId;
+
+        Upgrades.prepareUpgrade("ReferralGateway.sol", opts);
+    }
+}

--- a/deployments/testnet_ethereum_sepolia/ReferralGateway.json
+++ b/deployments/testnet_ethereum_sepolia/ReferralGateway.json
@@ -1,5 +1,5 @@
 {
-    "address": "0x567c3b31a85B6Eb15D9fA3318C6521Bf2454A7f1",
+    "address": "0x124638DBF88C191268ea26F5C7b07347F18a4860",
     "abi": [
         { "type": "constructor", "inputs": [], "stateMutability": "nonpayable" },
         {


### PR DESCRIPTION
This is a mainnet test to deploy implementation and propose an upgrade using OpenZeppelin Defender.

This will include the next changes against the current implementation:
1. `payContribution` will revert if the parent address is different than zero and not KYC
2. Refund calculation fixes
3. New function `refundByAdmin`
4. New function `fixContributionAmount` to be called before the first refund, this to fix the current values.

Notes:
This PR also removed `fixContributionAmount` this was done after the deployment, meaning the deployed contract has the function