### PR TITLE
chore: update CI/CD (TS-1227)

### DIFF
--- a/.github/workflows/01-sc_test_ci.yml
+++ b/.github/workflows/01-sc_test_ci.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: "nightly"
 
       - name: Forge Build
         run: |


### PR DESCRIPTION
Previously the foundry installer/updater defaults every installation/update to the nightly version. Now it is defaulted to the stable version since January 21. In the announcements they encourage to use the stable versions since the latest 0.3.0 release, this because the nightly will include experimental features for the 1.0.0 release. More about it [here](https://book.getfoundry.sh/announcements)