### PR TITLE
revise: add user address as a param in ccip send message and fix amounts (TS-1363)

### DIFF
--- a/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
@@ -53,7 +53,7 @@ contract TLDCcipReceiver is CCIPReceiver, Ownable2Step {
         bytes data,
         uint256 tokenAmount
     );
-    event OnMessageFailed(bytes32 indexed messageId, bytes reason);
+    event OnMessageFailed(bytes32 indexed messageId, bytes reason, address user);
     event OnMessageRecovered(bytes32 indexed messageId);
     event OnTokensRecovered(address indexed user, uint256 amount);
 
@@ -261,7 +261,8 @@ contract TLDCcipReceiver is CCIPReceiver, Ownable2Step {
                 amountReceived
             );
         } else {
-            emit OnMessageFailed(any2EvmMessage.messageId, returnData);
+            address _userAddress = _getNewMemberAddress(any2EvmMessage.data);
+            emit OnMessageFailed(any2EvmMessage.messageId, returnData, _userAddress);
         }
     }
 

--- a/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
@@ -248,12 +248,17 @@ contract TLDCcipReceiver is CCIPReceiver, Ownable2Step {
         // Low level call to the referral gateway
         (bool success, bytes memory returnData) = protocolGateway.call(any2EvmMessage.data);
         if (success) {
+            uint256 amountReceived;
+
+            if (any2EvmMessage.destTokenAmounts.length > 0)
+                amountReceived = any2EvmMessage.destTokenAmounts[0].amount;
+
             emit OnMessageReceived(
                 any2EvmMessage.messageId,
                 any2EvmMessage.sourceChainSelector,
                 abi.decode(any2EvmMessage.sender, (address)),
                 any2EvmMessage.data,
-                any2EvmMessage.destTokenAmounts[0].amount
+                amountReceived
             );
         } else {
             emit OnMessageFailed(any2EvmMessage.messageId, returnData);

--- a/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
@@ -248,17 +248,12 @@ contract TLDCcipReceiver is CCIPReceiver, Ownable2Step {
         // Low level call to the referral gateway
         (bool success, bytes memory returnData) = protocolGateway.call(any2EvmMessage.data);
         if (success) {
-            uint256 amountReceived;
-
-            if (any2EvmMessage.destTokenAmounts.length > 0)
-                amountReceived = any2EvmMessage.destTokenAmounts[0].amount;
-
             emit OnMessageReceived(
                 any2EvmMessage.messageId,
                 any2EvmMessage.sourceChainSelector,
                 abi.decode(any2EvmMessage.sender, (address)),
                 any2EvmMessage.data,
-                amountReceived
+                any2EvmMessage.destTokenAmounts[0].amount
             );
         } else {
             address _userAddress = _getNewMemberAddress(any2EvmMessage.data);

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -43,7 +43,12 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
 
     event OnNewSupportedToken(address token);
     event OnBackendProviderSet(address backendProvider);
-    event OnTokensTransferred(bytes32 indexed messageId, uint256 indexed tokenAmount, uint256 fees);
+    event OnTokensTransferred(
+        bytes32 indexed messageId,
+        uint256 indexed tokenAmount,
+        uint256 indexed fees,
+        address user
+    );
 
     error TLDCcipSender__NotZeroTransfer();
     error TLDCcipSender__AlreadySupportedToken();
@@ -259,7 +264,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         _messageId = router.ccipSend(destinationChainSelector, _message);
 
         // Emit an event with message details
-        emit OnTokensTransferred(_messageId, _amountToTransfer, _ccipFees);
+        emit OnTokensTransferred(_messageId, _amountToTransfer, _ccipFees, _newMember);
     }
 
     function _buildCCIPMessage(

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -250,10 +250,8 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         uint256 _ccipFees,
         Client.EVM2AnyMessage memory _message
     ) internal returns (bytes32 _messageId) {
-        if (_amountToTransfer > 0) {
-            IERC20(_tokenToTransfer).safeTransferFrom(_newMember, address(this), _amountToTransfer);
-            IERC20(_tokenToTransfer).approve(address(router), _amountToTransfer);
-        }
+        IERC20(_tokenToTransfer).safeTransferFrom(_newMember, address(this), _amountToTransfer);
+        IERC20(_tokenToTransfer).approve(address(router), _amountToTransfer);
 
         // Send the message through the router and store the returned message ID
         _messageId = router.ccipSend(destinationChainSelector, _message);
@@ -273,13 +271,8 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         uint256 _couponAmount
     ) internal view returns (Client.EVM2AnyMessage memory) {
         // Set the token amounts
-        Client.EVMTokenAmount[] memory tokenAmounts;
-        if (_amount > 0) {
-            tokenAmounts = new Client.EVMTokenAmount[](1);
-            tokenAmounts[0] = Client.EVMTokenAmount({token: _token, amount: _amount});
-        } else {
-            tokenAmounts = new Client.EVMTokenAmount[](0);
-        }
+        Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
+        tokenAmounts[0] = Client.EVMTokenAmount({token: _token, amount: _amount});
 
         // Function to call in the receiver contract
         // payContributionOnBehalfOf(uint256 contribution, string calldata tDAOName, address parent, address newMember, uint256 couponAmount)

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -58,6 +58,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
     error TLDCcipSender__AddressZeroNotAllowed();
     error TLDCcipSender__NotAuthorized();
     error TLDCcipSender__ContributionOutOfRange();
+    error TLDCcipSender__WrongTransferAmount();
 
     modifier notZeroAddress(address addressToCheck) {
         require(addressToCheck != address(0), TLDCcipSender__AddressZeroNotAllowed());
@@ -163,6 +164,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             contribution >= MINIMUM_CONTRIBUTION && contribution <= MAXIMUM_CONTRIBUTION,
             TLDCcipSender__ContributionOutOfRange()
         );
+        require(amountToTransfer <= contribution, TLDCcipSender__WrongTransferAmount());
 
         if (couponAmount > 0)
             require(msg.sender == backendProvider, TLDCcipSender__NotAuthorized());

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -148,6 +148,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         uint256 contribution,
         string calldata tDAOName,
         address parent,
+        address newMember,
         uint256 couponAmount
     ) external returns (bytes32 messageId) {
         require(isSupportedToken[tokenToTransfer], TLDCcipSender__NotSupportedToken());
@@ -166,6 +167,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             _contributionAmount: contribution,
             _tDAOName: tDAOName,
             _parent: parent,
+            _newMember: newMember,
             _couponAmount: couponAmount
         });
 
@@ -209,6 +211,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         uint256 _contributionAmount,
         string calldata _tDAOName,
         address _parent,
+        address _newMember,
         uint256 _couponAmount
     ) internal view returns (Client.EVM2AnyMessage memory _message) {
         // Create an EVM2AnyMessage struct in memory with necessary information for sending a cross-chain message
@@ -219,7 +222,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             _contribution: _contributionAmount,
             _tDAOName: _tDAOName,
             _parent: _parent,
-            _newMember: msg.sender,
+            _newMember: _newMember,
             _couponAmount: _couponAmount
         });
     }

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -45,6 +45,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
     event OnBackendProviderSet(address backendProvider);
     event OnTokensTransferred(bytes32 indexed messageId, uint256 indexed tokenAmount, uint256 fees);
 
+    error TLDCcipSender__NotZeroTransfer();
     error TLDCcipSender__AlreadySupportedToken();
     error TLDCcipSender__NotSupportedToken();
     error TLDCcipSender__NotEnoughBalance(uint256 currentBalance, uint256 calculatedFees);
@@ -151,6 +152,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address newMember,
         uint256 couponAmount
     ) external returns (bytes32 messageId) {
+        require(amountToTransfer > 0, TLDCcipSender__NotZeroTransfer());
         require(isSupportedToken[tokenToTransfer], TLDCcipSender__NotSupportedToken());
         require(
             contribution >= MINIMUM_CONTRIBUTION && contribution <= MAXIMUM_CONTRIBUTION,

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -50,7 +50,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address user
     );
 
-    error TLDCcipSender__NotZeroTransfer();
+    error TLDCcipSender__ZeroTransferNotAllowed();
     error TLDCcipSender__AlreadySupportedToken();
     error TLDCcipSender__NotSupportedToken();
     error TLDCcipSender__NotEnoughBalance(uint256 currentBalance, uint256 calculatedFees);
@@ -157,7 +157,7 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address newMember,
         uint256 couponAmount
     ) external returns (bytes32 messageId) {
-        require(amountToTransfer > 0, TLDCcipSender__NotZeroTransfer());
+        require(amountToTransfer > 0, TLDCcipSender__ZeroTransferNotAllowed());
         require(isSupportedToken[tokenToTransfer], TLDCcipSender__NotSupportedToken());
         require(
             contribution >= MINIMUM_CONTRIBUTION && contribution <= MAXIMUM_CONTRIBUTION,

--- a/deployments/testnet_arbitrum_sepolia/TLDCcipReceiver.json
+++ b/deployments/testnet_arbitrum_sepolia/TLDCcipReceiver.json
@@ -1,5 +1,5 @@
 {
-    "address": "0xb0c485ebef95822Ccbc80657885F5bF759066097",
+    "address": "0xB9890916a68458f6cBe43Fdb928bCdD2D261A4Ba",
     "abi": [
         {
             "type": "constructor",

--- a/deployments/testnet_arbitrum_sepolia/TLDCcipReceiver.json
+++ b/deployments/testnet_arbitrum_sepolia/TLDCcipReceiver.json
@@ -1,5 +1,5 @@
 {
-    "address": "0x2fD1e67fA58293e405391f77676d6a8fe9991665",
+    "address": "0xb0c485ebef95822Ccbc80657885F5bF759066097",
     "abi": [
         {
             "type": "constructor",

--- a/deployments/testnet_arbitrum_sepolia/TLDCcipReceiver.json
+++ b/deployments/testnet_arbitrum_sepolia/TLDCcipReceiver.json
@@ -245,7 +245,8 @@
                     "indexed": true,
                     "internalType": "bytes32"
                 },
-                { "name": "reason", "type": "bytes", "indexed": false, "internalType": "bytes" }
+                { "name": "reason", "type": "bytes", "indexed": false, "internalType": "bytes" },
+                { "name": "user", "type": "address", "indexed": false, "internalType": "address" }
             ],
             "anonymous": false
         },

--- a/deployments/testnet_base_sepolia/TLDCcipSender.json
+++ b/deployments/testnet_base_sepolia/TLDCcipSender.json
@@ -212,7 +212,8 @@
                     "indexed": true,
                     "internalType": "uint256"
                 },
-                { "name": "fees", "type": "uint256", "indexed": false, "internalType": "uint256" }
+                { "name": "fees", "type": "uint256", "indexed": true, "internalType": "uint256" },
+                { "name": "user", "type": "address", "indexed": false, "internalType": "address" }
             ],
             "anonymous": false
         },
@@ -309,6 +310,7 @@
             ]
         },
         { "type": "error", "name": "TLDCcipSender__NotSupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__NotZeroTransfer", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NothingToWithdraw", "inputs": [] },
         { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
         {

--- a/deployments/testnet_base_sepolia/TLDCcipSender.json
+++ b/deployments/testnet_base_sepolia/TLDCcipSender.json
@@ -119,6 +119,7 @@
                 { "name": "contribution", "type": "uint256", "internalType": "uint256" },
                 { "name": "tDAOName", "type": "string", "internalType": "string" },
                 { "name": "parent", "type": "address", "internalType": "address" },
+                { "name": "newMember", "type": "address", "internalType": "address" },
                 { "name": "couponAmount", "type": "uint256", "internalType": "uint256" }
             ],
             "outputs": [{ "name": "messageId", "type": "bytes32", "internalType": "bytes32" }],
@@ -297,6 +298,7 @@
         },
         { "type": "error", "name": "TLDCcipSender__AddressZeroNotAllowed", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__AlreadySupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__ContributionOutOfRange", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NotAuthorized", "inputs": [] },
         {
             "type": "error",

--- a/deployments/testnet_ethereum_sepolia/TLDCcipSender.json
+++ b/deployments/testnet_ethereum_sepolia/TLDCcipSender.json
@@ -212,7 +212,8 @@
                     "indexed": true,
                     "internalType": "uint256"
                 },
-                { "name": "fees", "type": "uint256", "indexed": false, "internalType": "uint256" }
+                { "name": "fees", "type": "uint256", "indexed": true, "internalType": "uint256" },
+                { "name": "user", "type": "address", "indexed": false, "internalType": "address" }
             ],
             "anonymous": false
         },
@@ -309,6 +310,7 @@
             ]
         },
         { "type": "error", "name": "TLDCcipSender__NotSupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__NotZeroTransfer", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NothingToWithdraw", "inputs": [] },
         { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
         {

--- a/deployments/testnet_ethereum_sepolia/TLDCcipSender.json
+++ b/deployments/testnet_ethereum_sepolia/TLDCcipSender.json
@@ -119,6 +119,7 @@
                 { "name": "contribution", "type": "uint256", "internalType": "uint256" },
                 { "name": "tDAOName", "type": "string", "internalType": "string" },
                 { "name": "parent", "type": "address", "internalType": "address" },
+                { "name": "newMember", "type": "address", "internalType": "address" },
                 { "name": "couponAmount", "type": "uint256", "internalType": "uint256" }
             ],
             "outputs": [{ "name": "messageId", "type": "bytes32", "internalType": "bytes32" }],
@@ -297,6 +298,7 @@
         },
         { "type": "error", "name": "TLDCcipSender__AddressZeroNotAllowed", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__AlreadySupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__ContributionOutOfRange", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NotAuthorized", "inputs": [] },
         {
             "type": "error",

--- a/deployments/testnet_optimism_sepolia/TLDCcipSender.json
+++ b/deployments/testnet_optimism_sepolia/TLDCcipSender.json
@@ -212,7 +212,8 @@
                     "indexed": true,
                     "internalType": "uint256"
                 },
-                { "name": "fees", "type": "uint256", "indexed": false, "internalType": "uint256" }
+                { "name": "fees", "type": "uint256", "indexed": true, "internalType": "uint256" },
+                { "name": "user", "type": "address", "indexed": false, "internalType": "address" }
             ],
             "anonymous": false
         },
@@ -309,6 +310,7 @@
             ]
         },
         { "type": "error", "name": "TLDCcipSender__NotSupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__NotZeroTransfer", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NothingToWithdraw", "inputs": [] },
         { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
         {

--- a/deployments/testnet_optimism_sepolia/TLDCcipSender.json
+++ b/deployments/testnet_optimism_sepolia/TLDCcipSender.json
@@ -119,6 +119,7 @@
                 { "name": "contribution", "type": "uint256", "internalType": "uint256" },
                 { "name": "tDAOName", "type": "string", "internalType": "string" },
                 { "name": "parent", "type": "address", "internalType": "address" },
+                { "name": "newMember", "type": "address", "internalType": "address" },
                 { "name": "couponAmount", "type": "uint256", "internalType": "uint256" }
             ],
             "outputs": [{ "name": "messageId", "type": "bytes32", "internalType": "bytes32" }],
@@ -297,6 +298,7 @@
         },
         { "type": "error", "name": "TLDCcipSender__AddressZeroNotAllowed", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__AlreadySupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__ContributionOutOfRange", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NotAuthorized", "inputs": [] },
         {
             "type": "error",

--- a/deployments/testnet_polygon_amoy/TLDCcipSender.json
+++ b/deployments/testnet_polygon_amoy/TLDCcipSender.json
@@ -212,7 +212,8 @@
                     "indexed": true,
                     "internalType": "uint256"
                 },
-                { "name": "fees", "type": "uint256", "indexed": false, "internalType": "uint256" }
+                { "name": "fees", "type": "uint256", "indexed": true, "internalType": "uint256" },
+                { "name": "user", "type": "address", "indexed": false, "internalType": "address" }
             ],
             "anonymous": false
         },
@@ -309,6 +310,7 @@
             ]
         },
         { "type": "error", "name": "TLDCcipSender__NotSupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__NotZeroTransfer", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NothingToWithdraw", "inputs": [] },
         { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
         {

--- a/deployments/testnet_polygon_amoy/TLDCcipSender.json
+++ b/deployments/testnet_polygon_amoy/TLDCcipSender.json
@@ -119,6 +119,7 @@
                 { "name": "contribution", "type": "uint256", "internalType": "uint256" },
                 { "name": "tDAOName", "type": "string", "internalType": "string" },
                 { "name": "parent", "type": "address", "internalType": "address" },
+                { "name": "newMember", "type": "address", "internalType": "address" },
                 { "name": "couponAmount", "type": "uint256", "internalType": "uint256" }
             ],
             "outputs": [{ "name": "messageId", "type": "bytes32", "internalType": "bytes32" }],
@@ -297,6 +298,7 @@
         },
         { "type": "error", "name": "TLDCcipSender__AddressZeroNotAllowed", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__AlreadySupportedToken", "inputs": [] },
+        { "type": "error", "name": "TLDCcipSender__ContributionOutOfRange", "inputs": [] },
         { "type": "error", "name": "TLDCcipSender__NotAuthorized", "inputs": [] },
         {
             "type": "error",


### PR DESCRIPTION
Short PR to add the user as an input when sending the message and to handle messages without transfers of tokens