### PR TITLE
chore: remove dao name instances (TS-1597)

### DIFF
--- a/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipReceiver.sol
@@ -263,7 +263,7 @@ contract TLDCcipReceiver is CCIPReceiver, Ownable2Step {
 
     function _getNewMemberAddress(bytes memory _data) internal pure returns (address _newMember) {
         // The data is structured to be able to call the function payContributionOnBehalfOf
-        // payContributionOnBehalfOf(uint256 contribution, string calldata tDAOName, address parent, address newMember, uint256 couponAmount)
+        // payContributionOnBehalfOf(uint256 contribution, address parent, address newMember, uint256 couponAmount)
 
         assembly {
             let _dataOffset := add(_data, 0x20) // Skip the first 32 bytes word from the data, this will point to the real place where the data starts

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -143,7 +143,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
      * @param tokenToTransfer The address of the token to be transferred. Must be in the list of supported tokens.
      * @param gasLimit gas allowed by the user to be the maximum spend in the destination blockchain by the CCIP protocol
      * @param contribution The amount of the contribution to be paid in the TLD contract.
-     * @param tDAOName The name of the DAO to point in the TLD contract.
      * @param parent The address of the parent if the caller has a referral.
      * @param couponAmount The amount of the coupon if the caller has one.
      * @return messageId The ID of the message that was sent.
@@ -153,7 +152,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address tokenToTransfer,
         uint256 gasLimit,
         uint256 contribution,
-        string calldata tDAOName,
         address parent,
         address newMember,
         uint256 couponAmount
@@ -174,7 +172,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             _tokenToTransfer: tokenToTransfer,
             _gasLimit: gasLimit,
             _contributionAmount: contribution,
-            _tDAOName: tDAOName,
             _parent: parent,
             _newMember: newMember,
             _couponAmount: couponAmount
@@ -219,7 +216,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address _tokenToTransfer,
         uint256 _gasLimit,
         uint256 _contributionAmount,
-        string calldata _tDAOName,
         address _parent,
         address _newMember,
         uint256 _couponAmount
@@ -230,7 +226,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             _amount: _amountToTransfer,
             _gasLimit: _gasLimit,
             _contribution: _contributionAmount,
-            _tDAOName: _tDAOName,
             _parent: _parent,
             _newMember: _newMember,
             _couponAmount: _couponAmount
@@ -274,7 +269,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         uint256 _amount,
         uint256 _gasLimit,
         uint256 _contribution,
-        string calldata _tDAOName,
         address _parent,
         address _newMember,
         uint256 _couponAmount
@@ -284,11 +278,10 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         tokenAmounts[0] = Client.EVMTokenAmount({token: _token, amount: _amount});
 
         // Function to call in the receiver contract
-        // payContributionOnBehalfOf(uint256 contribution, string calldata tDAOName, address parent, address newMember, uint256 couponAmount)
+        // payContributionOnBehalfOf(uint256 contribution, address parent, address newMember, uint256 couponAmount)
         bytes memory dataToSend = abi.encodeWithSignature(
-            "payContributionOnBehalfOf(uint256,string,address,address,uint256)",
+            "payContributionOnBehalfOf(uint256,address,address,uint256)",
             _contribution,
-            _tDAOName,
             _parent,
             _newMember,
             _couponAmount

--- a/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
+++ b/contracts/helpers/chainlink/ccip/TLDCcipSender.sol
@@ -44,7 +44,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         uint256 amount;
         uint256 gasLimit;
         uint256 contribution;
-        string tDAOName;
         address parent;
         address newMember;
         uint256 couponAmount;
@@ -168,7 +167,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
      * @param tokenToTransfer The address of the token to be transferred. Must be in the list of supported tokens.
      * @param gasLimit gas allowed by the user to be the maximum spend in the destination blockchain by the CCIP protocol
      * @param contribution The amount of the contribution to be paid in the TLD contract.
-     * @param tDAOName The name of the DAO to point in the TLD contract.
      * @param parent The address of the parent if the caller has a referral.
      * @param couponAmount The amount of the coupon if the caller has one.
      * @param membershipDuration The duration of the membership in seconds. Only used if prejoin is disabled.
@@ -179,7 +177,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address tokenToTransfer,
         uint256 gasLimit,
         uint256 contribution,
-        string calldata tDAOName,
         address parent,
         address newMember,
         uint256 couponAmount,
@@ -202,7 +199,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             _tokenToTransfer: tokenToTransfer,
             _gasLimit: gasLimit,
             _contributionAmount: contribution,
-            _tDAOName: tDAOName,
             _parent: parent,
             _newMember: newMember,
             _couponAmount: couponAmount,
@@ -247,7 +243,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
         address _tokenToTransfer,
         uint256 _gasLimit,
         uint256 _contributionAmount,
-        string calldata _tDAOName,
         address _parent,
         address _newMember,
         uint256 _couponAmount,
@@ -258,7 +253,6 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
             amount: _amountToTransfer,
             gasLimit: _gasLimit,
             contribution: _contributionAmount,
-            tDAOName: _tDAOName,
             parent: _parent,
             newMember: _newMember,
             couponAmount: _couponAmount,
@@ -320,11 +314,10 @@ contract TLDCcipSender is Initializable, UUPSUpgradeable, Ownable2StepUpgradeabl
 
         // Function to call in the receiver contract
         if (isPrejoinEnabled) {
-            // payContributionOnBehalfOf(uint256 contribution, string calldata tDAOName, address parent, address newMember, uint256 couponAmount)
+            // payContributionOnBehalfOf(uint256 contribution, address parent, address newMember, uint256 couponAmount)
             dataToSend = abi.encodeWithSignature(
-                "payContributionOnBehalfOf(uint256,string,address,address,uint256)",
+                "payContributionOnBehalfOf(uint256,address,address,uint256)",
                 _messageBuild.contribution,
-                _messageBuild.tDAOName,
                 _messageBuild.parent,
                 _messageBuild.newMember,
                 _messageBuild.couponAmount

--- a/contracts/modules/PrejoinModule.sol
+++ b/contracts/modules/PrejoinModule.sol
@@ -45,6 +45,8 @@ contract PrejoinModule is
     IERC20 public usdc;
     IBenefitMultiplierConsumer private bmConsumer;
 
+    string private constant DAO_NAME = "The LifeDAO";
+
     address private operator;
 
     mapping(string tDAOName => tDAO DAOData) private nameToDAOData;
@@ -53,8 +55,6 @@ contract PrejoinModule is
 
     address private couponPool;
     address private ccipReceiverContract;
-
-    string private tDAOName;
 
     ModuleState private moduleState;
 
@@ -192,13 +192,13 @@ contract PrejoinModule is
         require(launchDate > block.timestamp, PrejoinModule__InvalidLaunchDate());
 
         // Create the new DAO
-        nameToDAOData[tDAOName].name = tDAOName;
-        nameToDAOData[tDAOName].preJoinEnabled = isPreJoinEnabled;
-        nameToDAOData[tDAOName].referralDiscount = isReferralDiscountEnabled;
-        nameToDAOData[tDAOName].DAOAdmin = operator;
-        nameToDAOData[tDAOName].launchDate = launchDate;
-        nameToDAOData[tDAOName].objectiveAmount = objectiveAmount;
-        nameToDAOData[tDAOName].bmConsumer = IBenefitMultiplierConsumer(_bmConsumer);
+        nameToDAOData[DAO_NAME].name = DAO_NAME;
+        nameToDAOData[DAO_NAME].preJoinEnabled = isPreJoinEnabled;
+        nameToDAOData[DAO_NAME].referralDiscount = isReferralDiscountEnabled;
+        nameToDAOData[DAO_NAME].DAOAdmin = operator;
+        nameToDAOData[DAO_NAME].launchDate = launchDate;
+        nameToDAOData[DAO_NAME].objectiveAmount = objectiveAmount;
+        nameToDAOData[DAO_NAME].bmConsumer = IBenefitMultiplierConsumer(_bmConsumer);
 
         emit OnNewDAO(isPreJoinEnabled, isReferralDiscountEnabled, launchDate, objectiveAmount);
     }
@@ -208,10 +208,10 @@ contract PrejoinModule is
      */
     function updateLaunchDate(uint256 launchDate) external onlyRole(OPERATOR) {
         require(
-            nameToDAOData[tDAOName].DAOAddress == address(0),
+            nameToDAOData[DAO_NAME].DAOAddress == address(0),
             PrejoinModule__DAOAlreadyLaunched()
         );
-        nameToDAOData[tDAOName].launchDate = launchDate;
+        nameToDAOData[DAO_NAME].launchDate = launchDate;
 
         emit OnDAOLaunchDateUpdated(launchDate);
     }
@@ -233,15 +233,15 @@ contract PrejoinModule is
         AddressAndStates._notZeroAddress(tDAOAddress);
         AddressAndStates._notZeroAddress(entryModuleAddress);
         require(
-            nameToDAOData[tDAOName].DAOAddress == address(0),
+            nameToDAOData[DAO_NAME].DAOAddress == address(0),
             PrejoinModule__DAOAlreadyLaunched()
         );
 
-        nameToDAOData[tDAOName].preJoinEnabled = false;
-        nameToDAOData[tDAOName].referralDiscount = isReferralDiscountEnabled;
-        nameToDAOData[tDAOName].DAOAddress = tDAOAddress;
-        nameToDAOData[tDAOName].entryModule = entryModuleAddress;
-        nameToDAOData[tDAOName].launchDate = block.timestamp;
+        nameToDAOData[DAO_NAME].preJoinEnabled = false;
+        nameToDAOData[DAO_NAME].referralDiscount = isReferralDiscountEnabled;
+        nameToDAOData[DAO_NAME].DAOAddress = tDAOAddress;
+        nameToDAOData[DAO_NAME].entryModule = entryModuleAddress;
+        nameToDAOData[DAO_NAME].launchDate = block.timestamp;
 
         Reserve memory reserve = _getReservesValuesHook(ITakasureReserve(tDAOAddress));
 
@@ -259,9 +259,9 @@ contract PrejoinModule is
      * @notice Switch the referralDiscount status of a DAO
      */
     function switchReferralDiscount() external onlyRole(OPERATOR) {
-        nameToDAOData[tDAOName].referralDiscount = !nameToDAOData[tDAOName].referralDiscount;
+        nameToDAOData[DAO_NAME].referralDiscount = !nameToDAOData[DAO_NAME].referralDiscount;
 
-        emit OnReferralDiscountSwitched(nameToDAOData[tDAOName].referralDiscount);
+        emit OnReferralDiscountSwitched(nameToDAOData[DAO_NAME].referralDiscount);
     }
 
     /**
@@ -270,21 +270,21 @@ contract PrejoinModule is
      */
     function enableRepool(address rePoolAddress) external onlyRole(OPERATOR) {
         AddressAndStates._notZeroAddress(rePoolAddress);
-        require(nameToDAOData[tDAOName].DAOAddress != address(0), PrejoinModule__tDAONotReadyYet());
-        nameToDAOData[tDAOName].rePoolAddress = rePoolAddress;
+        require(nameToDAOData[DAO_NAME].DAOAddress != address(0), PrejoinModule__tDAONotReadyYet());
+        nameToDAOData[DAO_NAME].rePoolAddress = rePoolAddress;
 
         emit OnRepoolEnabled(rePoolAddress);
     }
 
     function transferToRepool() external onlyRole(OPERATOR) {
         require(moduleState != ModuleState.Deprecated, PrejoinModule__WrongModuleState());
-        require(nameToDAOData[tDAOName].rePoolAddress != address(0), PrejoinModule__ZeroAddress());
-        require(nameToDAOData[tDAOName].toRepool > 0, PrejoinModule__ZeroAmount());
+        require(nameToDAOData[DAO_NAME].rePoolAddress != address(0), PrejoinModule__ZeroAddress());
+        require(nameToDAOData[DAO_NAME].toRepool > 0, PrejoinModule__ZeroAmount());
 
-        uint256 amount = nameToDAOData[tDAOName].toRepool;
-        address rePoolAddress = nameToDAOData[tDAOName].rePoolAddress;
+        uint256 amount = nameToDAOData[DAO_NAME].toRepool;
+        address rePoolAddress = nameToDAOData[DAO_NAME].rePoolAddress;
 
-        nameToDAOData[tDAOName].toRepool = 0;
+        nameToDAOData[DAO_NAME].toRepool = 0;
 
         usdc.safeTransfer(rePoolAddress, amount);
     }
@@ -352,7 +352,7 @@ contract PrejoinModule is
 
         // The member must have already pre-paid
         require(
-            nameToDAOData[tDAOName].prepaidMembers[user].contributionBeforeFee != 0,
+            nameToDAOData[DAO_NAME].prepaidMembers[user].contributionBeforeFee != 0,
             PrejoinModule__HasNotPaid()
         );
 
@@ -366,12 +366,12 @@ contract PrejoinModule is
 
             uint256 layer = i + 1;
 
-            uint256 parentReward = nameToDAOData[tDAOName]
+            uint256 parentReward = nameToDAOData[DAO_NAME]
                 .prepaidMembers[parent]
                 .parentRewardsByChild[user];
 
             // Reset the rewards for this child
-            nameToDAOData[tDAOName].prepaidMembers[parent].parentRewardsByChild[user] = 0;
+            nameToDAOData[DAO_NAME].prepaidMembers[parent].parentRewardsByChild[user] = 0;
 
             usdc.safeTransfer(parent, parentReward);
 
@@ -397,24 +397,24 @@ contract PrejoinModule is
         require(isMemberKYCed[newMember], PrejoinModule__NotKYCed());
 
         require(
-            nameToDAOData[tDAOName].DAOAddress != address(0) &&
-                !nameToDAOData[tDAOName].preJoinEnabled,
+            nameToDAOData[DAO_NAME].DAOAddress != address(0) &&
+                !nameToDAOData[DAO_NAME].preJoinEnabled,
             PrejoinModule__tDAONotReadyYet()
         );
 
         uint256 membershipDuration = 60 * 60 * 24 * 365 * 5; // 5 years
 
         // Finally, we join the prepaidMember to the tDAO
-        IEntryModule(nameToDAOData[tDAOName].entryModule).joinPool(
+        IEntryModule(nameToDAOData[DAO_NAME].entryModule).joinPool(
             newMember,
             childToParent[newMember],
-            nameToDAOData[tDAOName].prepaidMembers[newMember].contributionBeforeFee,
+            nameToDAOData[DAO_NAME].prepaidMembers[newMember].contributionBeforeFee,
             membershipDuration
         );
 
         usdc.safeTransfer(
-            nameToDAOData[tDAOName].DAOAddress,
-            nameToDAOData[tDAOName].prepaidMembers[newMember].contributionAfterFee
+            nameToDAOData[DAO_NAME].DAOAddress,
+            nameToDAOData[DAO_NAME].prepaidMembers[newMember].contributionAfterFee
         );
     }
 
@@ -429,8 +429,8 @@ contract PrejoinModule is
      */
     function refundIfDAOIsNotLaunched(address member) external {
         require(
-            nameToDAOData[tDAOName].launchDate < block.timestamp &&
-                nameToDAOData[tDAOName].DAOAddress == address(0),
+            nameToDAOData[DAO_NAME].launchDate < block.timestamp &&
+                nameToDAOData[DAO_NAME].DAOAddress == address(0),
             PrejoinModule__tDAONotReadyYet()
         );
 
@@ -461,8 +461,8 @@ contract PrejoinModule is
         address newBenefitMultiplierConsumer
     ) external onlyRole(OPERATOR) {
         AddressAndStates._notZeroAddress(newBenefitMultiplierConsumer);
-        address oldBenefitMultiplierConsumer = address(nameToDAOData[tDAOName].bmConsumer);
-        nameToDAOData[tDAOName].bmConsumer = IBenefitMultiplierConsumer(
+        address oldBenefitMultiplierConsumer = address(nameToDAOData[DAO_NAME].bmConsumer);
+        nameToDAOData[DAO_NAME].bmConsumer = IBenefitMultiplierConsumer(
             newBenefitMultiplierConsumer
         );
 
@@ -518,26 +518,26 @@ contract PrejoinModule is
             uint256 discount
         )
     {
-        contributionBeforeFee = nameToDAOData[tDAOName]
+        contributionBeforeFee = nameToDAOData[DAO_NAME]
             .prepaidMembers[member]
             .contributionBeforeFee;
-        contributionAfterFee = nameToDAOData[tDAOName].prepaidMembers[member].contributionAfterFee;
-        feeToOperator = nameToDAOData[tDAOName].prepaidMembers[member].feeToOperator;
-        discount = nameToDAOData[tDAOName].prepaidMembers[member].discount;
+        contributionAfterFee = nameToDAOData[DAO_NAME].prepaidMembers[member].contributionAfterFee;
+        feeToOperator = nameToDAOData[DAO_NAME].prepaidMembers[member].feeToOperator;
+        discount = nameToDAOData[DAO_NAME].prepaidMembers[member].discount;
     }
 
     function getParentRewardsByChild(
         address parent,
         address child
     ) external view returns (uint256 rewards) {
-        rewards = nameToDAOData[tDAOName].prepaidMembers[parent].parentRewardsByChild[child];
+        rewards = nameToDAOData[DAO_NAME].prepaidMembers[parent].parentRewardsByChild[child];
     }
 
     function getParentRewardsByLayer(
         address parent,
         uint256 layer
     ) external view returns (uint256 rewards) {
-        rewards = nameToDAOData[tDAOName].prepaidMembers[parent].parentRewardsByLayer[layer];
+        rewards = nameToDAOData[DAO_NAME].prepaidMembers[parent].parentRewardsByLayer[layer];
     }
 
     function getDAOData()
@@ -556,16 +556,16 @@ contract PrejoinModule is
             uint256 referralReserve
         )
     {
-        preJoinEnabled = nameToDAOData[tDAOName].preJoinEnabled;
-        referralDiscount = nameToDAOData[tDAOName].referralDiscount;
-        DAOAddress = nameToDAOData[tDAOName].DAOAddress;
-        launchDate = nameToDAOData[tDAOName].launchDate;
-        objectiveAmount = nameToDAOData[tDAOName].objectiveAmount;
-        currentAmount = nameToDAOData[tDAOName].currentAmount;
-        collectedFees = nameToDAOData[tDAOName].collectedFees;
-        rePoolAddress = nameToDAOData[tDAOName].rePoolAddress;
-        toRepool = nameToDAOData[tDAOName].toRepool;
-        referralReserve = nameToDAOData[tDAOName].referralReserve;
+        preJoinEnabled = nameToDAOData[DAO_NAME].preJoinEnabled;
+        referralDiscount = nameToDAOData[DAO_NAME].referralDiscount;
+        DAOAddress = nameToDAOData[DAO_NAME].DAOAddress;
+        launchDate = nameToDAOData[DAO_NAME].launchDate;
+        objectiveAmount = nameToDAOData[DAO_NAME].objectiveAmount;
+        currentAmount = nameToDAOData[DAO_NAME].currentAmount;
+        collectedFees = nameToDAOData[DAO_NAME].collectedFees;
+        rePoolAddress = nameToDAOData[DAO_NAME].rePoolAddress;
+        toRepool = nameToDAOData[DAO_NAME].toRepool;
+        referralReserve = nameToDAOData[DAO_NAME].referralReserve;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -588,7 +588,7 @@ contract PrejoinModule is
         string memory memberAddressToString = Strings.toHexString(uint256(uint160(_member)), 20);
         string[] memory args = new string[](1);
         args[0] = memberAddressToString;
-        nameToDAOData[tDAOName].bmConsumer.sendRequest(args);
+        nameToDAOData[DAO_NAME].bmConsumer.sendRequest(args);
     }
 
     function _payContribution(
@@ -615,7 +615,7 @@ contract PrejoinModule is
             100;
         uint256 toReferralReserve;
 
-        if (nameToDAOData[tDAOName].referralDiscount) {
+        if (nameToDAOData[DAO_NAME].referralDiscount) {
             toReferralReserve = (realContribution * REFERRAL_RESERVE) / 100;
 
             if (_parent != address(0)) {
@@ -625,15 +625,15 @@ contract PrejoinModule is
 
                 childToParent[_newMember] = _parent;
 
-                (_finalFee, nameToDAOData[tDAOName].referralReserve) = _parentRewards({
+                (_finalFee, nameToDAOData[DAO_NAME].referralReserve) = _parentRewards({
                     _initialChildToCheck: _newMember,
                     _contribution: realContribution,
-                    _currentReferralReserve: nameToDAOData[tDAOName].referralReserve,
+                    _currentReferralReserve: nameToDAOData[DAO_NAME].referralReserve,
                     _toReferralReserve: toReferralReserve,
                     _currentFee: _finalFee
                 });
             } else {
-                nameToDAOData[tDAOName].referralReserve += toReferralReserve;
+                nameToDAOData[DAO_NAME].referralReserve += toReferralReserve;
             }
         }
 
@@ -646,12 +646,12 @@ contract PrejoinModule is
                 _finalFee + _discount + toReferralReserve + rePoolFee
         );
 
-        nameToDAOData[tDAOName].toRepool += rePoolFee;
-        nameToDAOData[tDAOName].currentAmount +=
+        nameToDAOData[DAO_NAME].toRepool += rePoolFee;
+        nameToDAOData[DAO_NAME].currentAmount +=
             realContribution -
             (realContribution * SERVICE_FEE_RATIO) /
             100;
-        nameToDAOData[tDAOName].collectedFees += _finalFee;
+        nameToDAOData[DAO_NAME].collectedFees += _finalFee;
 
         uint256 amountToTransfer = realContribution - _discount - _couponAmount;
 
@@ -677,14 +677,14 @@ contract PrejoinModule is
 
         usdc.safeTransfer(operator, _finalFee);
 
-        nameToDAOData[tDAOName].prepaidMembers[_newMember].member = _newMember;
-        nameToDAOData[tDAOName].prepaidMembers[_newMember].contributionBeforeFee = realContribution;
-        nameToDAOData[tDAOName].prepaidMembers[_newMember].contributionAfterFee =
+        nameToDAOData[DAO_NAME].prepaidMembers[_newMember].member = _newMember;
+        nameToDAOData[DAO_NAME].prepaidMembers[_newMember].contributionBeforeFee = realContribution;
+        nameToDAOData[DAO_NAME].prepaidMembers[_newMember].contributionAfterFee =
             realContribution -
             (realContribution * SERVICE_FEE_RATIO) /
             100;
-        nameToDAOData[tDAOName].prepaidMembers[_newMember].feeToOperator = _finalFee;
-        nameToDAOData[tDAOName].prepaidMembers[_newMember].discount = _discount;
+        nameToDAOData[DAO_NAME].prepaidMembers[_newMember].feeToOperator = _finalFee;
+        nameToDAOData[DAO_NAME].prepaidMembers[_newMember].discount = _discount;
 
         // Finally, we request the benefit multiplier for the member, this to have it ready when the member joins the DAO
         _getBenefitMultiplierFromOracle(_newMember);
@@ -700,14 +700,14 @@ contract PrejoinModule is
         // DAO must exist
 
         require(
-            nameToDAOData[tDAOName].preJoinEnabled ||
-                nameToDAOData[tDAOName].DAOAddress != address(0),
+            nameToDAOData[DAO_NAME].preJoinEnabled ||
+                nameToDAOData[DAO_NAME].DAOAddress != address(0),
             PrejoinModule__tDAONotReadyYet()
         );
 
         // We check if the member already exists
         require(
-            nameToDAOData[tDAOName].prepaidMembers[_newMember].contributionBeforeFee == 0,
+            nameToDAOData[DAO_NAME].prepaidMembers[_newMember].contributionBeforeFee == 0,
             PrejoinModule__AlreadyMember()
         );
 
@@ -736,13 +736,13 @@ contract PrejoinModule is
                 break;
             }
 
-            nameToDAOData[tDAOName]
+            nameToDAOData[DAO_NAME]
                 .prepaidMembers[childToParent[currentChildToCheck]]
                 .parentRewardsByChild[_initialChildToCheck] =
                 (_contribution * _referralRewardRatioByLayer(i + 1)) /
                 (100 * DECIMAL_CORRECTION);
 
-            nameToDAOData[tDAOName]
+            nameToDAOData[DAO_NAME]
                 .prepaidMembers[childToParent[currentChildToCheck]]
                 .parentRewardsByLayer[uint256(i + 1)] +=
                 (_contribution * _referralRewardRatioByLayer(i + 1)) /
@@ -772,13 +772,13 @@ contract PrejoinModule is
             PrejoinModule__WrongModuleState()
         );
         require(
-            nameToDAOData[tDAOName].prepaidMembers[_member].contributionBeforeFee != 0,
+            nameToDAOData[DAO_NAME].prepaidMembers[_member].contributionBeforeFee != 0,
             PrejoinModule__HasNotPaid()
         );
 
-        uint256 discountReceived = nameToDAOData[tDAOName].prepaidMembers[_member].discount;
+        uint256 discountReceived = nameToDAOData[DAO_NAME].prepaidMembers[_member].discount;
 
-        uint256 amountToRefund = nameToDAOData[tDAOName]
+        uint256 amountToRefund = nameToDAOData[DAO_NAME]
             .prepaidMembers[_member]
             .contributionBeforeFee - discountReceived;
 
@@ -790,31 +790,31 @@ contract PrejoinModule is
         uint256 leftover = amountToRefund;
 
         // We deduct first from the tDAO currentAmount only the part the member contributed
-        nameToDAOData[tDAOName].currentAmount -= nameToDAOData[tDAOName]
+        nameToDAOData[DAO_NAME].currentAmount -= nameToDAOData[DAO_NAME]
             .prepaidMembers[_member]
             .contributionAfterFee;
 
         // We update the leftover amount
-        leftover -= nameToDAOData[tDAOName].prepaidMembers[_member].contributionAfterFee;
+        leftover -= nameToDAOData[DAO_NAME].prepaidMembers[_member].contributionAfterFee;
 
         // We compare now against the referralReserve
-        if (leftover <= nameToDAOData[tDAOName].referralReserve) {
+        if (leftover <= nameToDAOData[DAO_NAME].referralReserve) {
             // If it is enough we deduct the leftover from the referralReserve
-            nameToDAOData[tDAOName].referralReserve -= leftover;
+            nameToDAOData[DAO_NAME].referralReserve -= leftover;
         } else {
             // We update the leftover value and set the referralReserve to 0
-            leftover -= nameToDAOData[tDAOName].referralReserve;
-            nameToDAOData[tDAOName].referralReserve = 0;
+            leftover -= nameToDAOData[DAO_NAME].referralReserve;
+            nameToDAOData[DAO_NAME].referralReserve = 0;
 
             // We compare now against the repool amount
-            if (leftover <= nameToDAOData[tDAOName].toRepool) {
-                nameToDAOData[tDAOName].toRepool -= leftover;
+            if (leftover <= nameToDAOData[DAO_NAME].toRepool) {
+                nameToDAOData[DAO_NAME].toRepool -= leftover;
             } else {
-                nameToDAOData[tDAOName].toRepool = 0;
+                nameToDAOData[DAO_NAME].toRepool = 0;
             }
         }
 
-        delete nameToDAOData[tDAOName].prepaidMembers[_member];
+        delete nameToDAOData[DAO_NAME].prepaidMembers[_member];
 
         isMemberKYCed[_member] = false;
 
@@ -832,9 +832,4 @@ contract PrejoinModule is
 
     ///@dev required by the OZ UUPS module
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(OPERATOR) {}
-
-    /// @dev this function can be removed when the contract is deployed
-    function setDAOName(string calldata newDAOName) external onlyRole(OPERATOR) {
-        tDAOName = newDAOName;
-    }
 }

--- a/contracts/modules/PrejoinModule.sol
+++ b/contracts/modules/PrejoinModule.sol
@@ -122,9 +122,7 @@ contract PrejoinModule is
     );
 
     error PrejoinModule__ZeroAddress();
-    error PrejoinModule__MustHaveName();
     error PrejoinModule__InvalidLaunchDate();
-    error PrejoinModule__AlreadyExists();
     error PrejoinModule__DAOAlreadyLaunched();
     error PrejoinModule__ZeroAmount();
     error PrejoinModule__ContributionOutOfRange();
@@ -175,7 +173,6 @@ contract PrejoinModule is
 
     /**
      * @notice Create a new DAO
-     * @param DAOName The name of the DAO
      * @param isPreJoinEnabled The pre-join status of the DAO
      * @param isReferralDiscountEnabled The referral discount status of the DAO
      * @param launchDate An estimated launch date of the DAO
@@ -186,28 +183,22 @@ contract PrejoinModule is
      * @dev The objective amount can be 0, if the DAO is already launched or the objective amount is not defined
      */
     function createDAO(
-        string calldata DAOName,
         bool isPreJoinEnabled,
         bool isReferralDiscountEnabled,
         uint256 launchDate,
         uint256 objectiveAmount,
         address _bmConsumer
     ) external onlyRole(OPERATOR) {
-        require(bytes(DAOName).length != 0, PrejoinModule__MustHaveName());
-        require(
-            !(Strings.equal(nameToDAOData[DAOName].name, DAOName)),
-            PrejoinModule__AlreadyExists()
-        );
         require(launchDate > block.timestamp, PrejoinModule__InvalidLaunchDate());
 
         // Create the new DAO
-        nameToDAOData[DAOName].name = DAOName;
-        nameToDAOData[DAOName].preJoinEnabled = isPreJoinEnabled;
-        nameToDAOData[DAOName].referralDiscount = isReferralDiscountEnabled;
-        nameToDAOData[DAOName].DAOAdmin = operator;
-        nameToDAOData[DAOName].launchDate = launchDate;
-        nameToDAOData[DAOName].objectiveAmount = objectiveAmount;
-        nameToDAOData[DAOName].bmConsumer = IBenefitMultiplierConsumer(_bmConsumer);
+        nameToDAOData[tDAOName].name = tDAOName;
+        nameToDAOData[tDAOName].preJoinEnabled = isPreJoinEnabled;
+        nameToDAOData[tDAOName].referralDiscount = isReferralDiscountEnabled;
+        nameToDAOData[tDAOName].DAOAdmin = operator;
+        nameToDAOData[tDAOName].launchDate = launchDate;
+        nameToDAOData[tDAOName].objectiveAmount = objectiveAmount;
+        nameToDAOData[tDAOName].bmConsumer = IBenefitMultiplierConsumer(_bmConsumer);
 
         emit OnNewDAO(isPreJoinEnabled, isReferralDiscountEnabled, launchDate, objectiveAmount);
     }

--- a/test/fuzzing/statefull_fuzz - invariants/PrejoinModuleInvariantTest.t.sol
+++ b/test/fuzzing/statefull_fuzz - invariants/PrejoinModuleInvariantTest.t.sol
@@ -63,15 +63,14 @@ contract PrejoinModuleInvariantTest is StdInvariant, Test {
         bmConsumerMock.setNewRequester(prejoinModuleAddress);
 
         vm.startPrank(daoAdmin);
+        prejoinModule.setDAOName(DAO_NAME);
         prejoinModule.createDAO(
-            DAO_NAME,
             true,
             true,
             block.timestamp + 31_536_000,
             0,
             address(bmConsumerMock)
         );
-        prejoinModule.setDAOName(DAO_NAME);
         vm.stopPrank();
 
         handler = new PrejoinModuleHandler(prejoinModule);

--- a/test/fuzzing/statefull_fuzz - invariants/PrejoinModuleInvariantTest.t.sol
+++ b/test/fuzzing/statefull_fuzz - invariants/PrejoinModuleInvariantTest.t.sol
@@ -63,7 +63,6 @@ contract PrejoinModuleInvariantTest is StdInvariant, Test {
         bmConsumerMock.setNewRequester(prejoinModuleAddress);
 
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(DAO_NAME);
         prejoinModule.createDAO(
             true,
             true,

--- a/test/fuzzing/stateless_fuzz - fuzz/03-Coupons_PrejoinModuleFuzzTest.t.sol
+++ b/test/fuzzing/stateless_fuzz - fuzz/03-Coupons_PrejoinModuleFuzzTest.t.sol
@@ -68,8 +68,8 @@ contract CouponCodeAndCcipFuzzTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());
@@ -97,6 +97,5 @@ contract CouponCodeAndCcipFuzzTest is Test {
             couponUser,
             couponAmount
         );
-
     }
 }

--- a/test/fuzzing/stateless_fuzz - fuzz/03-Coupons_PrejoinModuleFuzzTest.t.sol
+++ b/test/fuzzing/stateless_fuzz - fuzz/03-Coupons_PrejoinModuleFuzzTest.t.sol
@@ -68,7 +68,6 @@ contract CouponCodeAndCcipFuzzTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
 

--- a/test/fuzzing/stateless_fuzz - fuzz/03-PrejoinModuleFuzzTest.t.sol
+++ b/test/fuzzing/stateless_fuzz - fuzz/03-PrejoinModuleFuzzTest.t.sol
@@ -23,7 +23,6 @@ contract PrejoinModuleFuzzTest is Test {
     address couponPool = makeAddr("couponPool");
     address ccipReceiverContract = makeAddr("ccipReceiverContract");
     address couponRedeemer = makeAddr("couponRedeemer");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint256 public constant CONTRIBUTION_PREJOIN_DISCOUNT_RATIO = 10; // 10% of contribution deducted from fee
@@ -68,8 +67,7 @@ contract PrejoinModuleFuzzTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());

--- a/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
@@ -104,9 +104,6 @@ contract RevertsPrejoinModuleTest is Test {
                                CREATE DAO
     //////////////////////////////////////////////////////////////*/
     function testCreateANewDao() public {
-        vm.prank(takadao);
-        prejoinModule.setDAOName(tDaoName);
-
         vm.prank(referral);
         vm.expectRevert();
         prejoinModule.createDAO(
@@ -155,7 +152,6 @@ contract RevertsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
@@ -104,10 +104,12 @@ contract RevertsPrejoinModuleTest is Test {
                                CREATE DAO
     //////////////////////////////////////////////////////////////*/
     function testCreateANewDao() public {
+        vm.prank(takadao);
+        prejoinModule.setDAOName(tDaoName);
+
         vm.prank(referral);
         vm.expectRevert();
         prejoinModule.createDAO(
-            tDaoName,
             true,
             true,
             (block.timestamp + 31_536_000),
@@ -115,17 +117,14 @@ contract RevertsPrejoinModuleTest is Test {
             address(bmConsumerMock)
         );
 
-        vm.startPrank(takadao);
+        vm.prank(takadao);
         prejoinModule.createDAO(
-            tDaoName,
             true,
             true,
             (block.timestamp + 31_536_000),
             100e6,
             address(bmConsumerMock)
         );
-        prejoinModule.setDAOName(tDaoName);
-        vm.stopPrank();
 
         (
             bool prejoinEnabled,
@@ -156,8 +155,8 @@ contract RevertsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
@@ -31,7 +31,6 @@ contract RevertsPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
 
@@ -93,21 +92,10 @@ contract RevertsPrejoinModuleTest is Test {
     function testCreateANewDao() public {
         vm.prank(referral);
         vm.expectRevert();
-        prejoinModule.createDAO(
-            tDaoName,
-            true,
-            (block.timestamp + 31_536_000),
-            address(bmConsumerMock)
-        );
+        prejoinModule.createDAO(true, (block.timestamp + 31_536_000), address(bmConsumerMock));
 
         vm.startPrank(takadao);
-        prejoinModule.createDAO(
-            tDaoName,
-            true,
-            (block.timestamp + 31_536_000),
-            address(bmConsumerMock)
-        );
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, (block.timestamp + 31_536_000), address(bmConsumerMock));
         vm.stopPrank();
 
         (
@@ -141,8 +129,7 @@ contract RevertsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
@@ -32,7 +32,6 @@ contract LaunchDaoPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
 
@@ -92,8 +91,7 @@ contract LaunchDaoPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }
@@ -130,10 +128,6 @@ contract LaunchDaoPrejoinModuleTest is Test {
         vm.prank(daoAdmin);
         vm.expectRevert(AddressAndStates.TakasureProtocol__ZeroAddress.selector);
         prejoinModule.launchDAO(address(takasureReserve), address(0), true);
-
-        vm.prank(daoAdmin);
-        vm.expectRevert(PrejoinModule.PrejoinModule__InvalidLaunchDate.selector);
-        prejoinModule.launchDAO(address(takasureReserve), entryModuleAddress, true);
 
         vm.warp(launchDate);
         vm.roll(block.number + 1);

--- a/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
@@ -93,7 +93,6 @@ contract LaunchDaoPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
@@ -93,8 +93,8 @@ contract LaunchDaoPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
@@ -105,8 +105,8 @@ contract PrepaysPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
@@ -105,7 +105,6 @@ contract PrepaysPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
@@ -31,7 +31,6 @@ contract PrepaysPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint256 public constant LAYER_ONE_REWARD_RATIO = 4; // Layer one reward ratio 4%
@@ -103,8 +102,7 @@ contract PrepaysPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
@@ -94,8 +94,8 @@ contract JoinPrejoinModuleTest is Test, SimulateDonResponse {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
@@ -32,7 +32,6 @@ contract JoinPrejoinModuleTest is Test, SimulateDonResponse {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint8 public constant SERVICE_FEE_RATIO = 27;
@@ -93,8 +92,7 @@ contract JoinPrejoinModuleTest is Test, SimulateDonResponse {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
@@ -94,7 +94,6 @@ contract JoinPrejoinModuleTest is Test, SimulateDonResponse {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
@@ -30,7 +30,6 @@ contract GrandparentsPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint256 public constant LAYER_ONE_REWARD_RATIO = 4; // Layer one reward ratio 4%
@@ -99,8 +98,7 @@ contract GrandparentsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
@@ -101,7 +101,6 @@ contract GrandparentsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
@@ -101,8 +101,8 @@ contract GrandparentsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
@@ -90,7 +90,6 @@ contract RepoolPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
@@ -30,7 +30,6 @@ contract RepoolPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
 
@@ -88,8 +87,7 @@ contract RepoolPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
@@ -90,8 +90,8 @@ contract RepoolPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
@@ -30,7 +30,6 @@ contract RefundsPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint256 public constant CONTRIBUTION_PREJOIN_DISCOUNT_RATIO = 10; // 10% of contribution deducted from fee
@@ -90,8 +89,7 @@ contract RefundsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
@@ -92,7 +92,6 @@ contract RefundsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
@@ -92,8 +92,8 @@ contract RefundsPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
@@ -90,8 +90,8 @@ contract RolesPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
@@ -90,7 +90,6 @@ contract RolesPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;

--- a/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
@@ -30,7 +30,6 @@ contract RolesPrejoinModuleTest is Test {
     address member = makeAddr("member");
     address notMember = makeAddr("notMember");
     address child = makeAddr("child");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
 
@@ -88,8 +87,7 @@ contract RolesPrejoinModuleTest is Test {
 
     modifier createDao() {
         vm.startPrank(daoAdmin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/03-modules/01-prejoin-module/08-CouponCodeTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/08-CouponCodeTest.t.sol
@@ -21,7 +21,6 @@ contract CouponCodeTest is Test {
     address child = makeAddr("child");
     address couponPool = makeAddr("couponPool");
     address couponRedeemer = makeAddr("couponRedeemer");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint256 public constant CONTRIBUTION_PREJOIN_DISCOUNT_RATIO = 10; // 10% of contribution deducted from fee
@@ -55,8 +54,7 @@ contract CouponCodeTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());

--- a/test/unit/03-modules/01-prejoin-module/08-CouponCodeTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/08-CouponCodeTest.t.sol
@@ -55,8 +55,8 @@ contract CouponCodeTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());

--- a/test/unit/03-modules/01-prejoin-module/08-CouponCodeTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/08-CouponCodeTest.t.sol
@@ -55,7 +55,6 @@ contract CouponCodeTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
 

--- a/test/unit/03-modules/01-prejoin-module/09-CouponCodeAndCcipTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/09-CouponCodeAndCcipTest.t.sol
@@ -68,7 +68,6 @@ contract CouponCodeAndCcipTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
 

--- a/test/unit/03-modules/01-prejoin-module/09-CouponCodeAndCcipTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/09-CouponCodeAndCcipTest.t.sol
@@ -68,8 +68,8 @@ contract CouponCodeAndCcipTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());

--- a/test/unit/03-modules/01-prejoin-module/09-CouponCodeAndCcipTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/09-CouponCodeAndCcipTest.t.sol
@@ -23,7 +23,6 @@ contract CouponCodeAndCcipTest is Test {
     address couponPool = makeAddr("couponPool");
     address ccipReceiverContract = makeAddr("ccipReceiverContract");
     address couponRedeemer = makeAddr("couponRedeemer");
-    string tDaoName = "TheLifeDao";
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 USDC
     uint256 public constant CONTRIBUTION_AMOUNT = 25e6; // 25 USDC
     uint256 public constant CONTRIBUTION_PREJOIN_DISCOUNT_RATIO = 10; // 10% of contribution deducted from fee
@@ -68,8 +67,7 @@ contract CouponCodeAndCcipTest is Test {
         usdc.approve(address(prejoinModule), 1000e6);
 
         vm.startPrank(config.daoMultisig);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());

--- a/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
+++ b/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
@@ -284,7 +284,6 @@ contract TLDCcipTest is Test {
         uint256 amountToTransfer = 100e6;
         uint256 gasLimit = 1000000;
         uint256 contribution = 100e6;
-        string memory dao = "dao";
 
         vm.prank(user);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__NotSupportedToken.selector);
@@ -293,7 +292,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             0
@@ -305,7 +303,6 @@ contract TLDCcipTest is Test {
         uint256 gasLimit = 1000000;
         uint256 contribution = 50e6;
         uint256 coupon = 50e6;
-        string memory dao = "dao";
 
         vm.prank(backend);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__ZeroTransferNotAllowed.selector);
@@ -314,7 +311,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             coupon
@@ -326,7 +322,6 @@ contract TLDCcipTest is Test {
         uint256 gasLimit = 1000000;
         uint256 minContribution = 20e6;
         uint256 maxContribution = 300e6;
-        string memory dao = "dao";
 
         vm.startPrank(user);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__ContributionOutOfRange.selector);
@@ -335,7 +330,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             minContribution,
-            dao,
             address(0),
             user,
             0
@@ -347,7 +341,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             maxContribution,
-            dao,
             address(0),
             user,
             0
@@ -359,7 +352,6 @@ contract TLDCcipTest is Test {
         uint256 amountToTransfer = 100e6;
         uint256 gasLimit = 1000000;
         uint256 contribution = 50e6;
-        string memory dao = "dao";
 
         vm.prank(user);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__WrongTransferAmount.selector);
@@ -368,7 +360,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             0
@@ -379,7 +370,6 @@ contract TLDCcipTest is Test {
         uint256 amountToTransfer = 100e6;
         uint256 gasLimit = 1000000;
         uint256 contribution = 100e6;
-        string memory dao = "dao";
         uint256 coupon = 50e6;
 
         vm.prank(user);
@@ -389,7 +379,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             coupon
@@ -401,7 +390,7 @@ contract TLDCcipTest is Test {
         uint256 gasLimit = 1000000;
         uint256 contribution = 100e6;
 
-        bytes32 messageId = 0xe01b2be933401960d637314fd27f4fdf2caa6639d0f9ac6f78e7f21fe77c25d6;
+        bytes32 messageId = 0x891f0a4f29f72aecc7d2f0af25e9fa4ee8f0832bdf46411ea7d68956da4b812a;
 
         vm.startPrank(user);
         usdc.approve(senderAddress, amountToTransfer);
@@ -414,7 +403,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            tDaoName,
             address(0),
             user,
             0

--- a/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
+++ b/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
@@ -120,8 +120,8 @@ contract TLDCcipTest is Test {
 
     modifier createDao() {
         vm.startPrank(admin);
-        prejoinModule.createDAO(tDaoName, true, true, 1743479999, 1e12, address(bmConsumerMock));
         prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }

--- a/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
+++ b/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
@@ -40,7 +40,6 @@ contract TLDCcipTest is Test {
     uint256 public constant LINK_INITIAL_AMOUNT = 100e18; // 100 LINK
     uint256 public constant USDC_INITIAL_AMOUNT = 100e6; // 100 LINK
     uint256 public constant MEMBERSHIP_DURATION = 5 * 365 days; // 5 years
-    string tDaoName = "TheLifeDao";
 
     event OnNewSupportedToken(address token);
     event OnBackendProviderSet(address backendProvider);
@@ -122,8 +121,7 @@ contract TLDCcipTest is Test {
 
     modifier createDao() {
         vm.startPrank(admin);
-        prejoinModule.createDAO(tDaoName, true, 1743479999, address(bmConsumerMock));
-        prejoinModule.setDAOName(tDaoName);
+        prejoinModule.createDAO(true, 1743479999, address(bmConsumerMock));
         vm.stopPrank();
         _;
     }
@@ -286,7 +284,6 @@ contract TLDCcipTest is Test {
         uint256 amountToTransfer = 100e6;
         uint256 gasLimit = 1000000;
         uint256 contribution = 100e6;
-        string memory dao = "dao";
 
         vm.prank(user);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__NotSupportedToken.selector);
@@ -295,7 +292,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             0,
@@ -308,7 +304,6 @@ contract TLDCcipTest is Test {
         uint256 gasLimit = 1000000;
         uint256 contribution = 50e6;
         uint256 coupon = 50e6;
-        string memory dao = "dao";
 
         vm.prank(backend);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__ZeroTransferNotAllowed.selector);
@@ -317,7 +312,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             coupon,
@@ -330,7 +324,6 @@ contract TLDCcipTest is Test {
         uint256 gasLimit = 1000000;
         uint256 minContribution = 20e6;
         uint256 maxContribution = 300e6;
-        string memory dao = "dao";
 
         vm.startPrank(user);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__ContributionOutOfRange.selector);
@@ -339,7 +332,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             minContribution,
-            dao,
             address(0),
             user,
             0,
@@ -352,7 +344,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             maxContribution,
-            dao,
             address(0),
             user,
             0,
@@ -365,7 +356,6 @@ contract TLDCcipTest is Test {
         uint256 amountToTransfer = 100e6;
         uint256 gasLimit = 1000000;
         uint256 contribution = 50e6;
-        string memory dao = "dao";
 
         vm.prank(user);
         vm.expectRevert(TLDCcipSender.TLDCcipSender__WrongTransferAmount.selector);
@@ -374,7 +364,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             0,
@@ -386,7 +375,6 @@ contract TLDCcipTest is Test {
         uint256 amountToTransfer = 100e6;
         uint256 gasLimit = 1000000;
         uint256 contribution = 100e6;
-        string memory dao = "dao";
         uint256 coupon = 50e6;
 
         vm.prank(user);
@@ -396,7 +384,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            dao,
             address(0),
             user,
             coupon,
@@ -422,7 +409,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            tDaoName,
             address(0),
             user,
             0,
@@ -479,7 +465,7 @@ contract TLDCcipTest is Test {
         uint256 gasLimit = 1000000;
         uint256 contribution = 100e6;
 
-        bytes32 messageId = 0xe01b2be933401960d637314fd27f4fdf2caa6639d0f9ac6f78e7f21fe77c25d6;
+        bytes32 messageId = 0x891f0a4f29f72aecc7d2f0af25e9fa4ee8f0832bdf46411ea7d68956da4b812a;
 
         vm.startPrank(user);
         usdc.approve(senderAddress, amountToTransfer);
@@ -492,7 +478,6 @@ contract TLDCcipTest is Test {
             usdcAddress,
             gasLimit,
             contribution,
-            tDaoName,
             address(0),
             user,
             0,

--- a/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
+++ b/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
@@ -120,7 +120,6 @@ contract TLDCcipTest is Test {
 
     modifier createDao() {
         vm.startPrank(admin);
-        prejoinModule.setDAOName(tDaoName);
         prejoinModule.createDAO(true, true, 1743479999, 1e12, address(bmConsumerMock));
         vm.stopPrank();
         _;


### PR DESCRIPTION
Not only removed the DAOName from inputs, also made it constant, it is doable because it was not deployed yet so it was not taking any storage slot. 
The only thing with that is that inn uat we'll be having a new DAO, but as we are testing features dont think it is a problem