### PR TITLE
revise: make usdc immutable (TS-1594)

### DIFF
--- a/contracts/core/TakasureReserve.sol
+++ b/contracts/core/TakasureReserve.sol
@@ -214,11 +214,6 @@ contract TakasureReserve is
         emit TakasureEvents.OnNewMaximumThreshold(newMaximumThreshold);
     }
 
-    function setNewContributionToken(address newContributionToken) external onlyRole(DAO_MULTISIG) {
-        AddressAndStates._notZeroAddress(newContributionToken);
-        reserve.contributionToken = newContributionToken;
-    }
-
     function setNewFeeClaimAddress(address newFeeClaimAddress) external onlyRole(TAKADAO_OPERATOR) {
         AddressAndStates._notZeroAddress(newFeeClaimAddress);
         feeClaimAddress = newFeeClaimAddress;

--- a/contracts/modules/PrejoinModule.sol
+++ b/contracts/modules/PrejoinModule.sol
@@ -113,7 +113,6 @@ contract PrejoinModule is
         address indexed oldBenefitMultiplierConsumer
     );
     event OnRefund(address indexed member, uint256 indexed amount);
-    event OnUsdcAddressChanged(address indexed oldUsdc, address indexed newUsdc);
     event OnNewOperator(address indexed oldOperator, address indexed newOperator);
     event OnNewCouponPoolAddress(address indexed oldCouponPool, address indexed newCouponPool);
     event OnNewCCIPReceiverContract(
@@ -458,13 +457,6 @@ contract PrejoinModule is
     /*//////////////////////////////////////////////////////////////
                                 SETTERS
     //////////////////////////////////////////////////////////////*/
-
-    function setUsdcAddress(address _usdcAddress) external onlyRole(OPERATOR) {
-        address oldUsdc = address(usdc);
-        usdc = IERC20(_usdcAddress);
-
-        emit OnUsdcAddressChanged(oldUsdc, _usdcAddress);
-    }
 
     function setNewBenefitMultiplierConsumer(
         address newBenefitMultiplierConsumer

--- a/test/fuzzing/statefull_fuzz - invariants/PrejoinModuleInvariantTest.t.sol
+++ b/test/fuzzing/statefull_fuzz - invariants/PrejoinModuleInvariantTest.t.sol
@@ -54,10 +54,8 @@ contract PrejoinModuleInvariantTest is StdInvariant, Test {
         usdc = IUSDC(contributionTokenAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(contributionTokenAddress);
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(prejoinModuleAddress);

--- a/test/fuzzing/statefull_fuzz - invariants/ReferralGatewayInvariantTest.t.sol
+++ b/test/fuzzing/statefull_fuzz - invariants/ReferralGatewayInvariantTest.t.sol
@@ -54,10 +54,8 @@ contract ReferralGatewayInvariantTest is StdInvariant, Test {
         usdc = IUSDC(contributionTokenAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(contributionTokenAddress);
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(referralGatewayAddress);

--- a/test/unit/02-core/01-Setters_TakasureCoreTest.t.sol
+++ b/test/unit/02-core/01-Setters_TakasureCoreTest.t.sol
@@ -100,14 +100,6 @@ contract Setters_TakasureCoreTest is StdCheats, Test {
         assertEq(newMaximumThreshold, takasureReserve.getReserveValues().maximumThreshold);
     }
 
-    /// @dev Test the owner can set a new contribution token
-    function testTakasureCore_setNewContributionToken() public {
-        vm.prank(admin);
-        takasureReserve.setNewContributionToken(alice);
-
-        assertEq(alice, takasureReserve.getReserveValues().contributionToken);
-    }
-
     /// @dev Test the owner can set a new service claim address
     function testTakasureCore_cansetNewServiceClaimAddress() public {
         vm.prank(admin);

--- a/test/unit/02-core/02-Reverts_TakasureCoreTest.t.sol
+++ b/test/unit/02-core/02-Reverts_TakasureCoreTest.t.sol
@@ -63,20 +63,6 @@ contract Reverts_TakasureCoreTest is StdCheats, Test {
         takasureReserve.setNewMinimumThreshold(newThreshold);
     }
 
-    /// @dev `setNewContributionToken` must revert if the caller is not the admin
-    function testTakasureCore_setNewContributionTokenMustRevertIfTheCallerIsNotTheAdmin() public {
-        vm.prank(alice);
-        vm.expectRevert();
-        takasureReserve.setNewContributionToken(alice);
-    }
-
-    /// @dev `setNewContributionToken` must revert if the address is zero
-    function testTakasureCore_setNewContributionTokenMustRevertIfAddressZero() public {
-        vm.prank(admin);
-        vm.expectRevert(AddressAndStates.TakasureProtocol__ZeroAddress.selector);
-        takasureReserve.setNewContributionToken(address(0));
-    }
-
     /// @dev `setNewFeeClaimAddress` must revert if the caller is not the admin
     function testTakasureCore_setNewFeeClaimAddressMustRevertIfTheCallerIsNotTheAdmin() public {
         vm.prank(alice);

--- a/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/00-Reverts_PrejoinModuleTest.t.sol
@@ -66,10 +66,8 @@ contract RevertsPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));
@@ -87,17 +85,6 @@ contract RevertsPrejoinModuleTest is Test {
         usdc.approve(address(prejoinModule), USDC_INITIAL_AMOUNT);
         vm.prank(member);
         usdc.approve(address(takasureReserve), USDC_INITIAL_AMOUNT);
-    }
-
-    function testSetNewContributionToken() public {
-        assertEq(address(prejoinModule.usdc()), usdcAddress);
-
-        address newUSDC = makeAddr("newUSDC");
-
-        vm.prank(daoAdmin);
-        prejoinModule.setUsdcAddress(newUSDC);
-
-        assertEq(address(prejoinModule.usdc()), newUSDC);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/01-Launch_Dao_PrejoinModuleTest.t.sol
@@ -68,10 +68,8 @@ contract LaunchDaoPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/02-Prepays_PrejoinModuleTest.t.sol
@@ -80,10 +80,8 @@ contract PrepaysPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/03-Join_PrejoinModuleTest.t.sol
@@ -69,10 +69,8 @@ contract JoinPrejoinModuleTest is Test, SimulateDonResponse {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/04-Grandparents_PrejoinModuleTest.t.sol
@@ -76,10 +76,8 @@ contract GrandparentsPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/05-Repool_PrejoinModuleTest.t.sol
@@ -65,10 +65,8 @@ contract RepoolPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/06-Refund_PrejoinModuleTest.t.sol
@@ -67,10 +67,8 @@ contract RefundsPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
+++ b/test/unit/03-modules/01-prejoin-module/07-Roles_PrejoinModuleTest.t.sol
@@ -65,10 +65,8 @@ contract RolesPrejoinModuleTest is Test {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.startPrank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));

--- a/test/unit/03-modules/02-entry-module/03_Refund_EntryModuleTest.t.sol
+++ b/test/unit/03-modules/02-entry-module/03_Refund_EntryModuleTest.t.sol
@@ -126,13 +126,13 @@ contract Refund_EntryModuleTest is StdCheats, Test, SimulateDonResponse {
         // Cannot KYC someone who has been refunded until pays again
         vm.prank(kycService);
         vm.expectRevert(EntryModule.EntryModule__NoContribution.selector);
-        entryModule.setKYCStatus(alice);
+        entryModule.approveKYC(alice);
 
         vm.prank(alice);
         userRouter.joinPool(parent, CONTRIBUTION_AMOUNT, 5 * YEAR);
 
         vm.prank(kycService);
-        entryModule.setKYCStatus(alice);
+        entryModule.approveKYC(alice);
     }
 
     function testEntryModule_sameIdIfJoinsAgainAfterRefund() public {

--- a/test/unit/04-referral-gateway/ReferralGatewayTest.t.sol
+++ b/test/unit/04-referral-gateway/ReferralGatewayTest.t.sol
@@ -109,10 +109,8 @@ contract ReferralGatewayTest is Test, SimulateDonResponse {
         usdc = IUSDC(usdcAddress);
 
         // Config mocks
-        vm.startPrank(daoAdmin);
-        takasureReserve.setNewContributionToken(address(usdc));
+        vm.prank(daoAdmin);
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
-        vm.stopPrank();
 
         vm.prank(bmConsumerMock.admin());
         bmConsumerMock.setNewRequester(address(takasureReserve));
@@ -129,14 +127,6 @@ contract ReferralGatewayTest is Test, SimulateDonResponse {
         usdc.approve(address(referralGateway), USDC_INITIAL_AMOUNT);
         vm.prank(member);
         usdc.approve(address(takasureReserve), USDC_INITIAL_AMOUNT);
-
-        // Join the dao
-        // vm.prank(member);
-        // entryModule.joinPool(msg.sender, CONTRIBUTION_AMOUNT, 5);
-        // // We simulate a request before the KYC
-        // _successResponse(address(bmConsumerMock));
-        // vm.prank(daoAdmin);
-        // entryModule.setKYCStatus(member);
     }
 
     function testSetNewContributionToken() public {

--- a/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
+++ b/test/unit/05-chainlink/00-ccip/TLDCcipTest.t.sol
@@ -107,7 +107,6 @@ contract TLDCcipTest is Test {
 
         // Config mocks
         vm.startPrank(admin);
-        takasureReserve.setNewContributionToken(address(usdc));
         takasureReserve.setNewBenefitMultiplierConsumerAddress(address(bmConsumerMock));
         prejoinModule.setCCIPReceiverContract(address(receiver));
         vm.stopPrank();


### PR DESCRIPTION
It is not exactly immutable because:
- In `PrejoinModule` is already getting the storage slot 0
- In `TakasureReserve` will be fetched by all the other modules and think is easier to have it in the reserve struct rather than fetching it appart